### PR TITLE
Fix skipToken auto boxing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+- Fix `skipToken` auto boxing issue
+
 ## 0.0.5
 
 - Add `skipToken`

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ Widget build(BuildContext context) {
 }
 ```
 
-#### Query dependencies (with skipToken)
+#### Query dependencies
+
+A `null` queryFn acts the same as `enabled: false`
 
 ```dart
 final accountQuery = VoltQuery(
@@ -95,7 +97,7 @@ VoltQuery<Photos> photosQuery(Account? account) =>
     VoltQuery(
       queryKey: ['photos', account?.id],
       queryFn: account == null
-          ? skipToken
+          ? null
           : () async => fetch('https://jsonplaceholder.typicode.com/account/${account.id}/photos/'),
       select: Photos.fromJson,
     );
@@ -107,6 +109,10 @@ Widget build(BuildContext context) {
   ...
 }
 ```
+
+## API stability
+
+Volt's public API is not stable and may undergo breaking changes until version 1.0.0 is released.
 
 ## Credits
 

--- a/lib/src/hooks/use_query.dart
+++ b/lib/src/hooks/use_query.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:volt/src/query.dart';
 import 'package:volt/src/query_client_provider.dart';
-import 'package:volt/src/util.dart';
 
 /// Listens to a query and returns the result data
 ///
@@ -17,7 +16,7 @@ T? useQuery<T>(
 }) {
   final context = useContext();
   final client = QueryClientProvider.of(context);
-  final enabledQuery = enabled && !identical(query.queryFn, skipToken);
+  final enabledQuery = enabled && query.queryFn != null;
   
   final stream = useMemoized(
     () => enabledQuery

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -12,7 +12,7 @@ class VoltQuery<T> {
   /// The function to run the query
   ///
   /// This is the function that will be run to get the data for the query, generally a HTTP request
-  final Future<dynamic> Function() queryFn;
+  final Future<dynamic> Function()? queryFn;
 
   /// The function to select the data from the query
   ///

--- a/lib/src/query_client.dart
+++ b/lib/src/query_client.dart
@@ -192,7 +192,7 @@ class QueryClient {
     return await _conflateFuture.conflateByKey(
       key,
       () async {
-        var json = await query.queryFn();
+        var json = await query.queryFn!();
         listener?.onNetworkHit();
         // deserialize it before persisting it, in case source returns something unexpected
         final dynamic data;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,6 +1,0 @@
-/// A token that can be used to skip a query, used in queryFn.
-///
-/// This is used to skip a query when the query is not needed, behaves the same as enabled = false.
-T skipToken<T>() => throw UnsupportedError(
-      'skipToken should not actually be invoked. Only used for type checking.',
-    );

--- a/lib/volt.dart
+++ b/lib/volt.dart
@@ -10,4 +10,3 @@ export 'src/persister/persister.dart';
 export 'src/query.dart';
 export 'src/query_client.dart';
 export 'src/query_client_provider.dart';
-export 'src/util.dart';


### PR DESCRIPTION
Dart applies some form of auto boxing to function references when they are passed through a constructor or function params. This seems to happen when the function’s signature doesn’t match exactly - rather than throwing an error, Dart’s compiler automatically wraps the function reference.

This is problematic for `skipToken` as the reference needs to match exactly - instead I've made `queryFn` optional, when null it will act as disabled. 

Code sample showing auto boxing in action:
```
void main() {
  final wrapper = FunctionWrapper(skipToken);
  final areIdentical = identical(skipToken, wrapper.storedFunction);

  print('Are they identical? $areIdentical');
  print('Hash codes: ${skipToken.hashCode} ${wrapper.storedFunction.hashCode}');
}

class FunctionWrapper {
  final Function() storedFunction;

  FunctionWrapper(this.storedFunction);
}

T skipToken<T>() => throw UnsupportedError(
      'skipToken should not be invoked. It is only used for type checking.',
    );
```