### PR TITLE
Enable extra logging

### DIFF
--- a/lib/src/debug/logger.dart
+++ b/lib/src/debug/logger.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart';
 abstract class Logger {
   void logError(Object error, {StackTrace? stackTrace});
 
-  void logInfo(Object info, {StackTrace? stackTrace});
+  void logInfo(Object info, {Object? error, StackTrace? stackTrace});
 }
 
 class StdOutLogger implements Logger {
@@ -21,13 +21,12 @@ class StdOutLogger implements Logger {
   }
 
   @override
-  void logInfo(Object info, {StackTrace? stackTrace}) {
+  void logInfo(Object info, {Object? error, StackTrace? stackTrace}) {
     if (kDebugMode) {
       print('Volt info: $info');
 
-      if (stackTrace != null) {
-        print(stackTrace);
-      }
+      if (error != null) print(error);
+      if (stackTrace != null) print(stackTrace);
     }
   }
 }
@@ -39,5 +38,5 @@ class NoOpLogger implements Logger {
   void logError(Object error, {StackTrace? stackTrace}) {}
 
   @override
-  void logInfo(Object info, {StackTrace? stackTrace}) {}
+  void logInfo(Object info, {Object? error, StackTrace? stackTrace}) {}
 }

--- a/lib/src/query_client.dart
+++ b/lib/src/query_client.dart
@@ -181,6 +181,7 @@ class QueryClient {
       if (kDebugMode) {
         _logger.logInfo(
           'Failed to fetch from queryFn: $key',
+          error: e,
           stackTrace: stackTrace,
         );
       }


### PR DESCRIPTION
Issue: if something goes wrong with the queryFn sometimes it's hard to debug it because the error isn't getting logged, only the stacktrace