### PR TITLE
Revert disk persister attempted optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.2
+
+- Revert 1.0.1 optimisation to use openRead and transform
+
 # 1.0.1
 
 - Optimise disk persister to use readAsString/jsonDecode instead of openRead and transform

--- a/lib/src/persister/disk_volt_persister.dart
+++ b/lib/src/persister/disk_volt_persister.dart
@@ -183,8 +183,13 @@ class FileVoltPersistor implements VoltPersistor {
         }
         if (reportStats) listener?.onDiskCacheHit();
 
-        final dynamicData = jsonDecode(await dataFile.readAsString());
-        final jsonMetadata = jsonDecode(await metadataFile.readAsString());
+        final dynamicData = (await dataFile
+            .openRead()
+            .transform(const Utf8Decoder().fuse(const JsonDecoder()))
+            .first);
+
+        final metadataString = await metadataFile.readAsString();
+        final jsonMetadata = jsonDecode(metadataString);
 
         final T data = deserialiser(dynamicData);
         final timestamp = DateTime.parse(jsonMetadata['timestamp']);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: volt
 description: "Simple, fast, effortless data fetching and real-time updates"
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/lightyeardev/volt
 repository: https://github.com/lightyeardev/volt
 


### PR DESCRIPTION
It's faster runtime but one thing I hadn't considered is that with large objects it does the reading & encoding in a single event queue loop. Therefore causes more skipped frames.

Going to revert for now