### PR TITLE
Expose select duration in VoltListener

### DIFF
--- a/lib/src/query_client.dart
+++ b/lib/src/query_client.dart
@@ -199,7 +199,10 @@ class QueryClient {
         final dynamic data;
         try {
           final useCompute = query.useComputeIsolate && !kDebugMode;
+          final start = DateTime.now();
           data = useCompute ? await compute(query.select, json) : query.select(json);
+          final end = DateTime.now();
+          listener?.onQuerySelect(query, end.difference(start));
         } catch (error, stackTrace) {
           listener?.onDeserializationError();
           if (isDebug) {

--- a/lib/src/volt_listener.dart
+++ b/lib/src/volt_listener.dart
@@ -1,3 +1,5 @@
+import 'package:volt/volt.dart';
+
 /// A listener for query events in Volt
 abstract class VoltListener {
   /// Called when a memory cache hit occurs
@@ -29,4 +31,7 @@ abstract class VoltListener {
 
   /// Called when requests are conflated
   void onRequestConflated() {}
+
+  /// Called when select is invoked
+  void onQuerySelect(VoltQuery query, Duration duration) {}
 }


### PR DESCRIPTION
This is useful to log when a select takes a considerable amount of time of the frame budget