### PR TITLE
Add clearAll, evictStaleFiles, and fix _clearCache iteration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 1.0.2
 
 - Revert 1.0.1 optimisation to use openRead and transform
+- Add `invalidateAll`, `clearAll`, and `evictStaleDiskCache` for broader cache control
+- Fix `_clearCache` concurrent-modification bug
 
 # 1.0.1
 

--- a/lib/src/persister/disk_volt_persister.dart
+++ b/lib/src/persister/disk_volt_persister.dart
@@ -24,21 +24,30 @@ class FileVoltPersistor implements VoltPersistor {
     listener?.onMemoryCacheEviction,
   );
   static final lock = KeyedLock();
-  FileVoltPersistor({this.listener});
+  FileVoltPersistor({
+    this.listener,
+  });
 
   @override
   Stream<VoltPersistorResult<T>> listen<T>(String keyHash, VoltQuery<T> query) {
     final relativePath = _getRelativeFilePathWithFileName(keyHash, query.scope);
-    return Rx.concat([
-      Stream.fromFuture(_readFile(relativePath, query)),
-      observer
-          .watch(relativePath)
-          .asyncMap((_) => _readFile(relativePath, query, reportStats: false)),
-    ]);
+    return Rx.concat(
+      [
+        Stream.fromFuture(_readFile(relativePath, query)),
+        observer
+            .watch(relativePath)
+            .asyncMap((_) => _readFile(relativePath, query, reportStats: false)),
+      ],
+    );
   }
 
   @override
-  Future<bool> put<T>(String keyHash, VoltQuery<T> query, T dataObj, dynamic dataJson) async {
+  Future<bool> put<T>(
+    String keyHash,
+    VoltQuery<T> query,
+    T dataObj,
+    dynamic dataJson,
+  ) async {
     final timestamp = DateTime.now().toUtc();
     final data = HasData(dataObj, timestamp, query.scope);
     final relativePath = _getRelativeFilePathWithFileName(keyHash, query.scope);
@@ -50,11 +59,24 @@ class FileVoltPersistor implements VoltPersistor {
     cache[relativePath] = data;
 
     if (equals) {
-      unawaited(_writeMetadataFile(relativePath, data, query));
+      unawaited(
+        _writeMetadataFile(
+          relativePath,
+          data,
+          query,
+        ),
+      );
       return false;
     }
 
-    unawaited(_writeFile<T>(relativePath, dataJson, data, query));
+    unawaited(
+      _writeFile<T>(
+        relativePath,
+        dataJson,
+        data,
+        query,
+      ),
+    );
     observer.onFileChanged(relativePath);
 
     return true;
@@ -103,9 +125,9 @@ class FileVoltPersistor implements VoltPersistor {
         await file.create(recursive: true);
       }
 
-      await Stream.value(
-        json,
-      ).transform(const JsonEncoder().fuse(const Utf8Encoder())).pipe(file.openWrite());
+      await Stream.value(json)
+          .transform(const JsonEncoder().fuse(const Utf8Encoder()))
+          .pipe(file.openWrite());
 
       await _writeMetadataFileUnlocked(relativePath, data, query);
     });
@@ -121,7 +143,9 @@ class FileVoltPersistor implements VoltPersistor {
     }
 
     await lock.synchronized(
-        relativePath, () => _writeMetadataFileUnlocked(relativePath, data, query));
+      relativePath,
+      () => _writeMetadataFileUnlocked(relativePath, data, query),
+    );
   }
 
   Future<void> _writeMetadataFileUnlocked(
@@ -133,13 +157,11 @@ class FileVoltPersistor implements VoltPersistor {
     if (!(await metadataFile.exists())) {
       await metadataFile.create(recursive: true);
     }
-    await metadataFile.writeAsString(
-      jsonEncode({
-        'queryKey': query.queryKey,
-        'timestamp': data.timestamp.toIso8601String(),
-        'staleDurationMs': query.staleDuration?.inMilliseconds,
-      }),
-    );
+    await metadataFile.writeAsString(jsonEncode({
+      'queryKey': query.queryKey,
+      'timestamp': data.timestamp.toIso8601String(),
+      'staleDurationMs': query.staleDuration?.inMilliseconds,
+    }));
   }
 
   Future<VoltPersistorResult<T>> _readFile<T>(
@@ -211,10 +233,12 @@ class FileVoltPersistor implements VoltPersistor {
 
   Future<void> clear(List<String?> scopes) async {
     await Future.wait(
-      scopes.map((scope) async {
-        await _clearDirectory(scope);
-        _clearCache(scope);
-      }),
+      scopes.map(
+        (scope) async {
+          await _clearDirectory(scope);
+          _clearCache(scope);
+        },
+      ),
     );
   }
 

--- a/lib/src/persister/disk_volt_persister.dart
+++ b/lib/src/persister/disk_volt_persister.dart
@@ -24,30 +24,21 @@ class FileVoltPersistor implements VoltPersistor {
     listener?.onMemoryCacheEviction,
   );
   static final lock = KeyedLock();
-  FileVoltPersistor({
-    this.listener,
-  });
+  FileVoltPersistor({this.listener});
 
   @override
   Stream<VoltPersistorResult<T>> listen<T>(String keyHash, VoltQuery<T> query) {
     final relativePath = _getRelativeFilePathWithFileName(keyHash, query.scope);
-    return Rx.concat(
-      [
-        Stream.fromFuture(_readFile(relativePath, query)),
-        observer
-            .watch(relativePath)
-            .asyncMap((_) => _readFile(relativePath, query, reportStats: false)),
-      ],
-    );
+    return Rx.concat([
+      Stream.fromFuture(_readFile(relativePath, query)),
+      observer
+          .watch(relativePath)
+          .asyncMap((_) => _readFile(relativePath, query, reportStats: false)),
+    ]);
   }
 
   @override
-  Future<bool> put<T>(
-    String keyHash,
-    VoltQuery<T> query,
-    T dataObj,
-    dynamic dataJson,
-  ) async {
+  Future<bool> put<T>(String keyHash, VoltQuery<T> query, T dataObj, dynamic dataJson) async {
     final timestamp = DateTime.now().toUtc();
     final data = HasData(dataObj, timestamp, query.scope);
     final relativePath = _getRelativeFilePathWithFileName(keyHash, query.scope);
@@ -59,26 +50,11 @@ class FileVoltPersistor implements VoltPersistor {
     cache[relativePath] = data;
 
     if (equals) {
-      unawaited(
-        _writeMetadataFile(
-          relativePath,
-          data,
-          query.disableDiskCache,
-          query,
-        ),
-      );
+      unawaited(_writeMetadataFile(relativePath, data, query));
       return false;
     }
 
-    unawaited(
-      _writeFile<T>(
-        relativePath,
-        dataJson,
-        data,
-        query.disableDiskCache,
-        query,
-      ),
-    );
+    unawaited(_writeFile<T>(relativePath, dataJson, data, query));
     observer.onFileChanged(relativePath);
 
     return true;
@@ -100,6 +76,14 @@ class FileVoltPersistor implements VoltPersistor {
     _clearCache(scope);
   }
 
+  @override
+  Future<void> clearAll() async {
+    final appDirectory = await _getSafeApplicationDirectoryPath();
+    final directory = Directory('$appDirectory/persistor');
+    await directory.deleteSafely();
+    cache.evictAll();
+  }
+
   static bool _deepEquals<T>((Object?, T) record) =>
       const DeepCollectionEquality().equals(record.$1, record.$2);
 
@@ -107,10 +91,9 @@ class FileVoltPersistor implements VoltPersistor {
     String relativePath,
     Object? json,
     HasData<T> data,
-    bool disableDiskCache,
     VoltQuery query,
   ) async {
-    if (disableDiskCache || !(await hasEnoughDiskSpace)) {
+    if (query.disableDiskCache || !(await hasEnoughDiskSpace)) {
       return;
     }
 
@@ -120,37 +103,43 @@ class FileVoltPersistor implements VoltPersistor {
         await file.create(recursive: true);
       }
 
-      await Stream.value(json)
-          .transform(const JsonEncoder().fuse(const Utf8Encoder()))
-          .pipe(file.openWrite());
+      await Stream.value(
+        json,
+      ).transform(const JsonEncoder().fuse(const Utf8Encoder())).pipe(file.openWrite());
 
-      await _writeMetadataFile(
-        relativePath,
-        data,
-        disableDiskCache,
-        query,
-      );
+      await _writeMetadataFileUnlocked(relativePath, data, query);
     });
   }
 
   Future<void> _writeMetadataFile(
     String relativePath,
     HasData<dynamic> data,
-    bool disableDiskCache,
     VoltQuery query,
   ) async {
-    if (disableDiskCache) {
+    if (query.disableDiskCache) {
       return;
     }
 
+    await lock.synchronized(
+        relativePath, () => _writeMetadataFileUnlocked(relativePath, data, query));
+  }
+
+  Future<void> _writeMetadataFileUnlocked(
+    String relativePath,
+    HasData<dynamic> data,
+    VoltQuery query,
+  ) async {
     final metadataFile = await _getFile(relativePath, 'metadata');
     if (!(await metadataFile.exists())) {
       await metadataFile.create(recursive: true);
     }
-    await metadataFile.writeAsString(jsonEncode({
-      'queryKey': query.queryKey,
-      'timestamp': data.timestamp.toIso8601String(),
-    }));
+    await metadataFile.writeAsString(
+      jsonEncode({
+        'queryKey': query.queryKey,
+        'timestamp': data.timestamp.toIso8601String(),
+        'staleDurationMs': query.staleDuration?.inMilliseconds,
+      }),
+    );
   }
 
   Future<VoltPersistorResult<T>> _readFile<T>(
@@ -222,21 +211,95 @@ class FileVoltPersistor implements VoltPersistor {
 
   Future<void> clear(List<String?> scopes) async {
     await Future.wait(
-      scopes.map(
-        (scope) async {
-          await _clearDirectory(scope);
-          _clearCache(scope);
-        },
-      ),
+      scopes.map((scope) async {
+        await _clearDirectory(scope);
+        _clearCache(scope);
+      }),
     );
   }
 
   void _clearCache(String? scope) {
+    final keysToRemove = <String>[];
     cache.forEach((key, value) {
       if (value.scope == scope) {
-        cache.remove(key);
+        keysToRemove.add(key);
       }
     });
+    for (final key in keysToRemove) {
+      cache.remove(key);
+    }
+  }
+
+  static Future<int> evictStaleFiles({Duration maxAge = const Duration(days: 7)}) async {
+    final appDirectory = await _getSafeApplicationDirectoryPath();
+    final persistorDir = Directory('$appDirectory/persistor');
+    if (!await persistorDir.exists()) return 0;
+
+    int deletedCount = 0;
+    final now = DateTime.now().toUtc();
+
+    await for (final entity in persistorDir.list(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.metadata')) continue;
+
+      final relativePath = _getRelativePathForMetadataFile(appDirectory, entity.path);
+      await lock.synchronized(relativePath, () async {
+        if (!await entity.exists()) {
+          return;
+        }
+
+        try {
+          final content = await entity.readAsString();
+          final json = jsonDecode(content);
+          final timestamp = DateTime.parse(json['timestamp']);
+          final fileStaleDuration = json['staleDurationMs'] != null
+              ? Duration(milliseconds: json['staleDurationMs'])
+              : Duration.zero;
+          final effectiveMaxAge = maxAge > fileStaleDuration ? maxAge : fileStaleDuration;
+          final cutoff = now.subtract(effectiveMaxAge);
+
+          if (timestamp.isBefore(cutoff)) {
+            await _deletePersistedFiles(entity);
+            deletedCount++;
+          }
+        } catch (_) {
+          await _deletePersistedFiles(entity);
+          deletedCount++;
+        }
+      });
+    }
+
+    return deletedCount;
+  }
+
+  static Future<void> _deletePersistedFiles(File metadataFile) async {
+    await File(_swapFileExtension(metadataFile.path, from: 'metadata', to: 'json')).deleteSafely();
+    await metadataFile.deleteSafely();
+  }
+
+  static String _getRelativePathForMetadataFile(String appDirectory, String metadataPath) {
+    final prefix = '$appDirectory/';
+    final relativeMetadataPath =
+        metadataPath.startsWith(prefix) ? metadataPath.substring(prefix.length) : metadataPath;
+    const suffix = '.metadata';
+
+    if (relativeMetadataPath.endsWith(suffix)) {
+      return relativeMetadataPath.substring(0, relativeMetadataPath.length - suffix.length);
+    }
+
+    return relativeMetadataPath;
+  }
+
+  static String _swapFileExtension(
+    String path, {
+    required String from,
+    required String to,
+  }) {
+    final fromSuffix = '.$from';
+    if (!path.endsWith(fromSuffix)) {
+      return path;
+    }
+
+    return '${path.substring(0, path.length - fromSuffix.length)}.$to';
   }
 
   Future<bool> get hasEnoughDiskSpace async {

--- a/lib/src/persister/persister.dart
+++ b/lib/src/persister/persister.dart
@@ -1,11 +1,22 @@
 import 'package:volt/src/query.dart';
 
 abstract class VoltPersistor {
-  Stream<VoltPersistorResult<T>> listen<T>(String key, VoltQuery<T> query);
+  Stream<VoltPersistorResult<T>> listen<T>(
+    String key,
+    VoltQuery<T> query,
+  );
 
-  Future<bool> put<T>(String key, VoltQuery<T> query, T dataObj, dynamic data);
+  Future<bool> put<T>(
+    String key,
+    VoltQuery<T> query,
+    T dataObj,
+    dynamic data,
+  );
 
-  VoltPersistorResult<T> peak<T>(String key, VoltQuery<T> query);
+  VoltPersistorResult<T> peak<T>(
+    String key,
+    VoltQuery<T> query,
+  );
 
   Future<void> clearScope(String? scope);
 

--- a/lib/src/persister/persister.dart
+++ b/lib/src/persister/persister.dart
@@ -1,24 +1,15 @@
 import 'package:volt/src/query.dart';
 
 abstract class VoltPersistor {
-  Stream<VoltPersistorResult<T>> listen<T>(
-    String key,
-    VoltQuery<T> query,
-  );
+  Stream<VoltPersistorResult<T>> listen<T>(String key, VoltQuery<T> query);
 
-  Future<bool> put<T>(
-    String key,
-    VoltQuery<T> query,
-    T dataObj,
-    dynamic data,
-  );
+  Future<bool> put<T>(String key, VoltQuery<T> query, T dataObj, dynamic data);
 
-  VoltPersistorResult<T> peak<T>(
-    String key,
-    VoltQuery<T> query,
-  );
+  VoltPersistorResult<T> peak<T>(String key, VoltQuery<T> query);
 
   Future<void> clearScope(String? scope);
+
+  Future<void> clearAll();
 }
 
 sealed class VoltPersistorResult<T> {}

--- a/lib/src/query_client.dart
+++ b/lib/src/query_client.dart
@@ -62,33 +62,30 @@ class QueryClient {
     int index = 0;
     final key = toStableKey(query);
     final threshold = staleDuration ?? query.staleDuration ?? this.staleDuration;
+    final effectiveQuery = _queryWithPersistedStaleDuration(query, threshold);
 
-    return Rx.merge(
-      [
-        persistor.listen(key, query),
-        _createPollingStream(key, query),
-      ],
-    ).switchMap<T>(
-      (persistedValue) {
-        if (index++ == 0) {
-          if (persistedValue is HasData) {
-            final entry = persistedValue as HasData<T>;
-            if (entry.timestamp.add(threshold).isBefore(DateTime.now().toUtc())) {
-              return _sourceWithExponentialBackoff(key, query).startWith(entry.data);
-            } else {
-              return Stream.value(entry.data);
-            }
-          } else if (persistedValue is NoData) {
-            return _sourceWithExponentialBackoff(key, query);
+    return Rx.merge([
+      persistor.listen(key, effectiveQuery),
+      _createPollingStream(key, effectiveQuery),
+    ]).switchMap<T>((persistedValue) {
+      if (index++ == 0) {
+        if (persistedValue is HasData) {
+          final entry = persistedValue as HasData<T>;
+          if (entry.timestamp.add(threshold).isBefore(DateTime.now().toUtc())) {
+            return _sourceWithExponentialBackoff(key, effectiveQuery).startWith(entry.data);
           } else {
-            throw 'Unexpected value: $persistedValue';
+            return Stream.value(entry.data);
           }
-        } else if (persistedValue is HasData) {
-          return Stream.value((persistedValue as HasData<T>).data);
+        } else if (persistedValue is NoData) {
+          return _sourceWithExponentialBackoff(key, effectiveQuery);
+        } else {
+          throw 'Unexpected value: $persistedValue';
         }
-        return const Stream.empty();
-      },
-    );
+      } else if (persistedValue is HasData) {
+        return Stream.value((persistedValue as HasData<T>).data);
+      }
+      return const Stream.empty();
+    });
   }
 
   /// Prefetches and caches the result of a query.
@@ -98,8 +95,12 @@ class QueryClient {
   /// by reducing wait times.
   Future<bool> prefetchQuery<T>(VoltQuery<T> query) async {
     final key = toStableKey(query);
+    final effectiveQuery = _queryWithPersistedStaleDuration(
+      query,
+      query.staleDuration ?? staleDuration,
+    );
 
-    return await _sourceAndPersist(key, query) is! _Failure<T>;
+    return await _sourceAndPersist(key, effectiveQuery) is! _Failure<T>;
   }
 
   /// Fetches and caches the result of a query, throwing an error if the fetch fails.
@@ -113,22 +114,40 @@ class QueryClient {
   /// Throws an error if the fetch operation fails.
   Future<T> fetchQueryOrThrow<T>(VoltQuery<T> query) async {
     final key = toStableKey(query);
+    final effectiveQuery = _queryWithPersistedStaleDuration(
+      query,
+      query.staleDuration ?? staleDuration,
+    );
 
-    final (data, _) = await _sourceAndPersistOrThrow(key, query);
+    final (data, _) = await _sourceAndPersistOrThrow(key, effectiveQuery);
     return data;
   }
 
   /// Invalidates all queries within the specified scope.
   ///
   /// This method clears the cache for all queries associated with the given [scope].
-  /// If [scope] is null, it will invalidate all queries regardless of their scope.
+  /// If [scope] is null, it clears the default (unscoped) cache bucket only.
   ///
-  /// Use this method when you want to force a refresh of all data within a particular scope,
-  /// or when you want to clear all cached data if no scope is specified.
+  /// To clear ALL scopes at once, use [invalidateAll] instead.
   ///
   /// Returns a [Future] that completes when the invalidation process is finished.
   Future<void> invalidateScope(String? scope) async {
     await persistor.clearScope(scope);
+  }
+
+  /// Invalidates all cached data across every scope.
+  ///
+  /// This deletes the entire disk cache directory and clears the in-memory cache.
+  /// Use on logout or when a full cache reset is needed.
+  Future<void> invalidateAll() async {
+    await persistor.clearAll();
+  }
+
+  /// Evicts disk-cached entries older than [maxAge].
+  ///
+  /// Returns the number of evicted entries. Safe to call as fire-and-forget on app startup.
+  static Future<int> evictStaleDiskCache({Duration maxAge = const Duration(days: 7)}) {
+    return FileVoltPersistor.evictStaleFiles(maxAge: maxAge);
   }
 
   Stream<T> _createPollingStream<T>(String key, VoltQuery<T> query) {
@@ -138,9 +157,9 @@ class QueryClient {
     }
     return _conflateStream.conflateByKey(
       key,
-      () => Stream.periodic(pollingDuration)
-          .switchMap((value) => _sourceAndPersist(key, query).asStream())
-          .listen(null),
+      () => Stream.periodic(
+        pollingDuration,
+      ).switchMap((value) => _sourceAndPersist(key, query).asStream()).listen(null),
       listener,
     );
   }
@@ -151,25 +170,26 @@ class QueryClient {
     Duration? retryDuration,
   }) {
     final localRetryDuration = retryDuration ?? Duration.zero;
-    return Rx.timer(key, localRetryDuration)
-        .asyncMap((_) => _sourceAndPersist(key, query))
-        .flatMap((result) {
-      if (result is _Success || result is _NoChange) {
-        return const Stream.empty();
-      } else if (result is _Failure) {
-        return _sourceWithExponentialBackoff(
-          key,
-          query,
-          retryDuration: Duration(
-            seconds: (localRetryDuration.inSeconds * 1.5)
-                .round()
-                .clamp(_minRetrySecondDuration, _maxRetrySecondDuration),
-          ),
-        );
-      } else {
-        throw 'Unexpected value: $result';
-      }
-    });
+    return Rx.timer(key, localRetryDuration).asyncMap((_) => _sourceAndPersist(key, query)).flatMap(
+      (result) {
+        if (result is _Success || result is _NoChange) {
+          return const Stream.empty();
+        } else if (result is _Failure) {
+          return _sourceWithExponentialBackoff(
+            key,
+            query,
+            retryDuration: Duration(
+              seconds: (localRetryDuration.inSeconds * 1.5).round().clamp(
+                    _minRetrySecondDuration,
+                    _maxRetrySecondDuration,
+                  ),
+            ),
+          );
+        } else {
+          throw 'Unexpected value: $result';
+        }
+      },
+    );
   }
 
   Future<_VoltResult<T>> _sourceAndPersist<T>(String key, VoltQuery<T> query) async {
@@ -179,45 +199,56 @@ class QueryClient {
     } catch (e, stackTrace) {
       listener?.onNetworkError();
       if (kDebugMode) {
-        _logger.logInfo(
-          'Failed to fetch from queryFn: $key',
-          error: e,
-          stackTrace: stackTrace,
-        );
+        _logger.logInfo('Failed to fetch from queryFn: $key', error: e, stackTrace: stackTrace);
       }
       return _Failure(e);
     }
   }
 
   Future<(T, bool)> _sourceAndPersistOrThrow<T>(String key, VoltQuery<T> query) async {
-    return await _conflateFuture.conflateByKey(
-      key,
-      () async {
-        var json = await query.queryFn!();
-        listener?.onNetworkHit();
-        // deserialize it before persisting it, in case source returns something unexpected
-        final dynamic data;
-        try {
-          final useCompute = query.useComputeIsolate && !kDebugMode;
-          final start = DateTime.now();
-          data = useCompute ? await compute(query.select, json) : query.select(json);
-          final end = DateTime.now();
-          listener?.onQuerySelect(query, end.difference(start));
-        } catch (error, stackTrace) {
-          listener?.onDeserializationError();
-          if (isDebug) {
-            _logger.logInfo('Failed to deserialize data from source: $json',
-                stackTrace: stackTrace);
-          } else {
-            _logger.logInfo(error, stackTrace: stackTrace);
-          }
-          rethrow;
+    return await _conflateFuture.conflateByKey(key, () async {
+      var json = await query.queryFn!();
+      listener?.onNetworkHit();
+      // deserialize it before persisting it, in case source returns something unexpected
+      final dynamic data;
+      try {
+        final useCompute = query.useComputeIsolate && !kDebugMode;
+        final start = DateTime.now();
+        data = useCompute ? await compute(query.select, json) : query.select(json);
+        final end = DateTime.now();
+        listener?.onQuerySelect(query, end.difference(start));
+      } catch (error, stackTrace) {
+        listener?.onDeserializationError();
+        if (isDebug) {
+          _logger.logInfo('Failed to deserialize data from source: $json', stackTrace: stackTrace);
+        } else {
+          _logger.logInfo(error, stackTrace: stackTrace);
         }
+        rethrow;
+      }
 
-        final persisted = await persistor.put<T>(key, query, data as T, json);
-        return (data, persisted);
-      },
-      listener,
+      final persisted = await persistor.put<T>(key, query, data as T, json);
+      return (data, persisted);
+    }, listener);
+  }
+
+  VoltQuery<T> _queryWithPersistedStaleDuration<T>(
+    VoltQuery<T> query,
+    Duration effectiveStaleDuration,
+  ) {
+    if (query.staleDuration == effectiveStaleDuration) {
+      return query;
+    }
+
+    return VoltQuery<T>(
+      queryKey: query.queryKey,
+      queryFn: query.queryFn,
+      select: query.select,
+      staleDuration: effectiveStaleDuration,
+      useComputeIsolate: query.useComputeIsolate,
+      disableDiskCache: query.disableDiskCache,
+      scope: query.scope,
+      pollingDuration: query.pollingDuration,
     );
   }
 

--- a/lib/src/query_client.dart
+++ b/lib/src/query_client.dart
@@ -64,28 +64,32 @@ class QueryClient {
     final threshold = staleDuration ?? query.staleDuration ?? this.staleDuration;
     final effectiveQuery = _queryWithPersistedStaleDuration(query, threshold);
 
-    return Rx.merge([
-      persistor.listen(key, effectiveQuery),
-      _createPollingStream(key, effectiveQuery),
-    ]).switchMap<T>((persistedValue) {
-      if (index++ == 0) {
-        if (persistedValue is HasData) {
-          final entry = persistedValue as HasData<T>;
-          if (entry.timestamp.add(threshold).isBefore(DateTime.now().toUtc())) {
-            return _sourceWithExponentialBackoff(key, effectiveQuery).startWith(entry.data);
+    return Rx.merge(
+      [
+        persistor.listen(key, effectiveQuery),
+        _createPollingStream(key, effectiveQuery),
+      ],
+    ).switchMap<T>(
+      (persistedValue) {
+        if (index++ == 0) {
+          if (persistedValue is HasData) {
+            final entry = persistedValue as HasData<T>;
+            if (entry.timestamp.add(threshold).isBefore(DateTime.now().toUtc())) {
+              return _sourceWithExponentialBackoff(key, effectiveQuery).startWith(entry.data);
+            } else {
+              return Stream.value(entry.data);
+            }
+          } else if (persistedValue is NoData) {
+            return _sourceWithExponentialBackoff(key, effectiveQuery);
           } else {
-            return Stream.value(entry.data);
+            throw 'Unexpected value: $persistedValue';
           }
-        } else if (persistedValue is NoData) {
-          return _sourceWithExponentialBackoff(key, effectiveQuery);
-        } else {
-          throw 'Unexpected value: $persistedValue';
+        } else if (persistedValue is HasData) {
+          return Stream.value((persistedValue as HasData<T>).data);
         }
-      } else if (persistedValue is HasData) {
-        return Stream.value((persistedValue as HasData<T>).data);
-      }
-      return const Stream.empty();
-    });
+        return const Stream.empty();
+      },
+    );
   }
 
   /// Prefetches and caches the result of a query.
@@ -157,9 +161,9 @@ class QueryClient {
     }
     return _conflateStream.conflateByKey(
       key,
-      () => Stream.periodic(
-        pollingDuration,
-      ).switchMap((value) => _sourceAndPersist(key, query).asStream()).listen(null),
+      () => Stream.periodic(pollingDuration)
+          .switchMap((value) => _sourceAndPersist(key, query).asStream())
+          .listen(null),
       listener,
     );
   }
@@ -170,26 +174,25 @@ class QueryClient {
     Duration? retryDuration,
   }) {
     final localRetryDuration = retryDuration ?? Duration.zero;
-    return Rx.timer(key, localRetryDuration).asyncMap((_) => _sourceAndPersist(key, query)).flatMap(
-      (result) {
-        if (result is _Success || result is _NoChange) {
-          return const Stream.empty();
-        } else if (result is _Failure) {
-          return _sourceWithExponentialBackoff(
-            key,
-            query,
-            retryDuration: Duration(
-              seconds: (localRetryDuration.inSeconds * 1.5).round().clamp(
-                    _minRetrySecondDuration,
-                    _maxRetrySecondDuration,
-                  ),
-            ),
-          );
-        } else {
-          throw 'Unexpected value: $result';
-        }
-      },
-    );
+    return Rx.timer(key, localRetryDuration)
+        .asyncMap((_) => _sourceAndPersist(key, query))
+        .flatMap((result) {
+      if (result is _Success || result is _NoChange) {
+        return const Stream.empty();
+      } else if (result is _Failure) {
+        return _sourceWithExponentialBackoff(
+          key,
+          query,
+          retryDuration: Duration(
+            seconds: (localRetryDuration.inSeconds * 1.5)
+                .round()
+                .clamp(_minRetrySecondDuration, _maxRetrySecondDuration),
+          ),
+        );
+      } else {
+        throw 'Unexpected value: $result';
+      }
+    });
   }
 
   Future<_VoltResult<T>> _sourceAndPersist<T>(String key, VoltQuery<T> query) async {
@@ -199,37 +202,46 @@ class QueryClient {
     } catch (e, stackTrace) {
       listener?.onNetworkError();
       if (kDebugMode) {
-        _logger.logInfo('Failed to fetch from queryFn: $key', error: e, stackTrace: stackTrace);
+        _logger.logInfo(
+          'Failed to fetch from queryFn: $key',
+          error: e,
+          stackTrace: stackTrace,
+        );
       }
       return _Failure(e);
     }
   }
 
   Future<(T, bool)> _sourceAndPersistOrThrow<T>(String key, VoltQuery<T> query) async {
-    return await _conflateFuture.conflateByKey(key, () async {
-      var json = await query.queryFn!();
-      listener?.onNetworkHit();
-      // deserialize it before persisting it, in case source returns something unexpected
-      final dynamic data;
-      try {
-        final useCompute = query.useComputeIsolate && !kDebugMode;
-        final start = DateTime.now();
-        data = useCompute ? await compute(query.select, json) : query.select(json);
-        final end = DateTime.now();
-        listener?.onQuerySelect(query, end.difference(start));
-      } catch (error, stackTrace) {
-        listener?.onDeserializationError();
-        if (isDebug) {
-          _logger.logInfo('Failed to deserialize data from source: $json', stackTrace: stackTrace);
-        } else {
-          _logger.logInfo(error, stackTrace: stackTrace);
+    return await _conflateFuture.conflateByKey(
+      key,
+      () async {
+        var json = await query.queryFn!();
+        listener?.onNetworkHit();
+        // deserialize it before persisting it, in case source returns something unexpected
+        final dynamic data;
+        try {
+          final useCompute = query.useComputeIsolate && !kDebugMode;
+          final start = DateTime.now();
+          data = useCompute ? await compute(query.select, json) : query.select(json);
+          final end = DateTime.now();
+          listener?.onQuerySelect(query, end.difference(start));
+        } catch (error, stackTrace) {
+          listener?.onDeserializationError();
+          if (isDebug) {
+            _logger.logInfo('Failed to deserialize data from source: $json',
+                stackTrace: stackTrace);
+          } else {
+            _logger.logInfo(error, stackTrace: stackTrace);
+          }
+          rethrow;
         }
-        rethrow;
-      }
 
-      final persisted = await persistor.put<T>(key, query, data as T, json);
-      return (data, persisted);
-    }, listener);
+        final persisted = await persistor.put<T>(key, query, data as T, json);
+        return (data, persisted);
+      },
+      listener,
+    );
   }
 
   VoltQuery<T> _queryWithPersistedStaleDuration<T>(

--- a/test/mocks/mock_persistor.dart
+++ b/test/mocks/mock_persistor.dart
@@ -35,10 +35,32 @@ class InMemoryPersistor extends VoltPersistor {
   }
 
   @override
+  Future<void> clearAll() async {
+    _cache.clear();
+  }
+
+  @override
   VoltPersistorResult<T> peak<T>(String key, VoltQuery<T> query) {
     final data = _cache[key]?.value;
     if (data is HasData<T>) return data;
 
     return NoData<T>();
+  }
+}
+
+class TrackingPersistor extends InMemoryPersistor {
+  Duration? lastListenStaleDuration;
+  Duration? lastPutStaleDuration;
+
+  @override
+  Stream<VoltPersistorResult<T>> listen<T>(String key, VoltQuery<T> query) {
+    lastListenStaleDuration = query.staleDuration;
+    return super.listen(key, query);
+  }
+
+  @override
+  Future<bool> put<T>(String key, VoltQuery<T> query, T dataObj, dynamic data) {
+    lastPutStaleDuration = query.staleDuration;
+    return super.put(key, query, dataObj, data);
   }
 }

--- a/test/query_client_test.dart
+++ b/test/query_client_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:volt/volt.dart';
 
 import 'mocks/mock_query_client.dart';
+import 'mocks/mock_persistor.dart';
 
 void main() {
   test('when cache is empty, streamQuery emits the result of the query function', () async {
@@ -66,6 +67,45 @@ void main() {
       stream,
       emitsInOrder([randomNumber1, randomNumber2]),
     );
+  });
+
+  test('prefetchQuery persists the client staleDuration when the query does not override it',
+      () async {
+    final persistor = TrackingPersistor();
+    final client = QueryClient(
+      persistor: persistor,
+      staleDuration: const Duration(hours: 6),
+    );
+    final query = VoltQuery(
+      queryKey: ['test'],
+      queryFn: () async => 42,
+      select: (d) => d,
+    );
+
+    await client.prefetchQuery(query);
+
+    expect(persistor.lastPutStaleDuration, const Duration(hours: 6));
+  });
+
+  test('streamQuery passes staleDuration overrides through to the persistor', () async {
+    final persistor = TrackingPersistor();
+    final client = QueryClient(
+      persistor: persistor,
+      staleDuration: const Duration(hours: 1),
+    );
+    final query = VoltQuery(
+      queryKey: ['test'],
+      queryFn: () async => 99,
+      select: (d) => d,
+    );
+
+    await expectLater(
+      client.streamQuery(query, staleDuration: const Duration(days: 1)),
+      emits(99),
+    );
+
+    expect(persistor.lastListenStaleDuration, const Duration(days: 1));
+    expect(persistor.lastPutStaleDuration, const Duration(days: 1));
   });
 
   test(


### PR DESCRIPTION
## Summary
- Add `clearAll()` to `VoltPersistor` / `FileVoltPersistor` — deletes entire `persistor/` directory + clears in-memory cache. For use on logout to clear all scope buckets at once.
- Add `invalidateAll()` to `QueryClient` — delegates to `clearAll()`
- Add `evictStaleFiles(maxAge)` — static method to prune disk-cached entries older than `maxAge`. Respects per-query `staleDuration` stored in metadata so queries with longer stale periods aren't prematurely evicted (uses `max(maxAge, staleDuration)` per file). Corrupted metadata files are also cleaned up.
- Store `staleDurationMs` in `.metadata` files (backwards-compatible — old files without it fall back to `maxAge`)
- Fix `_clearCache` bug: was mutating the LRU linked list during `forEach` iteration. Now collects keys first, then removes.
- Clarify `invalidateScope` docs to note it only clears one scope bucket
- Update `InMemoryPersistor` test mock with `clearAll()`

## Test plan
- [x] All 11 existing tests pass (`flutter test`)
- [ ] Manual: verify `.metadata` files contain `staleDurationMs` field after a `put`
- [ ] Manual: verify `evictStaleFiles` respects per-query stale duration


🤖 Generated with [Claude Code](https://claude.com/claude-code)