### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 1.0.2
+# 1.1.0
 
 - Revert 1.0.1 optimisation to use openRead and transform
 - Add `invalidateAll`, `clearAll`, and `evictStaleDiskCache` for broader cache control
+- Add `onQuerySelect` to `VoltListener` to expose select duration
 - Fix `_clearCache` concurrent-modification bug
 
 # 1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: volt
 description: "Simple, fast, effortless data fetching and real-time updates"
-version: 1.0.2
+version: 1.1.0
 homepage: https://github.com/lightyeardev/volt
 repository: https://github.com/lightyeardev/volt
 


### PR DESCRIPTION
## Summary
- Bump pubspec version from 1.0.2 to 1.1.0
- Update CHANGELOG heading and add notes for the new `VoltPersistor.clearAll` and `VoltListener.onQuerySelect` additions

## Why
The unreleased changes add a new abstract `clearAll()` method to the `VoltPersistor` interface without a default implementation. This is a breaking change for anyone with a custom `VoltPersistor` subclass, so per SemVer this warrants a minor bump rather than a patch.

## Test plan
- [ ] `flutter pub get` succeeds
- [ ] CI passes